### PR TITLE
Listener to consume `issue_comments` webhook, parse and send ETH to address.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,3 +2,6 @@ FROM node:7-onbuild
 
 ENV PORT 8080
 EXPOSE 8080
+
+ENV NAME autobounty
+ENV STANDARD_BOUNTY 0.001

--- a/index.js
+++ b/index.js
@@ -1,3 +1,10 @@
+/*
+ * Bot that receives a POST request (from a GitHub issue comment webhook)
+ * and in case it's a comment that has "@autobounty <decimal> <currency>"
+ * awards that bounty to the address posted earlier in the thread (by the
+ * commiteth bot).
+ */
+
 const SignerProvider = require('ethjs-provider-signer');
 const sign = require('ethjs-signer').sign;
 const Eth = require('ethjs-query');
@@ -16,13 +23,14 @@ var express = require('express'),
 
 app.use(cors());
 
-app.get('/address/:address', function(req, res, next){
+// Receive a POST request at the address specified by an env. var.
+app.post('/address/:address', function(req, res, next){
   eth.getTransactionCount(address, (err, nonce) => {
     eth.sendTransaction({
-      from: address,
-      to: req.params.address,
+      from: address, // Specified in webhook, secret
+      to: req.params.address, // TODO replace with address from earlier in the thread
       gas: 100000,
-      value: (parseFloat(process.env.AMOUNT) || 1.5) * 1e18,
+      value: (parseFloat(process.env.AMOUNT) || 1.5) * 1e18, // TODO replace with parsed amount from comments
       data: '0xde5f72fd', // sha3('faucet()')
       nonce,
     }, (err, txID) => {

--- a/index.js
+++ b/index.js
@@ -20,8 +20,11 @@ const eth = new Eth(provider);
 
 var express = require('express'),
     cors = require('cors'),
-    app = express();
+    app = express(),
+    bodyParser = require('body-parser'),
+    jsonParser = bodyParser.json();
 
+app.use(jsonParser);
 app.use(cors());
 
 // Receive a POST request at the address specified by an env. var.

--- a/index.js
+++ b/index.js
@@ -40,4 +40,4 @@ app.get('/address/:address', function(req, res, next){
 
 const port = process.env.PORT || 8181
 app.listen(port, function(){
-  console.log('Faucet listening on port', port);
+  console.log('Autobounty listening on port', port);

--- a/index.js
+++ b/index.js
@@ -33,14 +33,14 @@ app.use(cors());
 var issueData = {};
 
 // Receive a POST request at the address specified by an env. var.
-app.post('/address/:address', jsonParser, function(req, res, next){
+app.post('/' + address.toString(), jsonParser, function(req, res, next){
   if (!req.body)
     return res.sendStatus(400);
   var commentBody = req.body.comment.body;
   var issueId = req.body.issue.id;
   var namePosition = commentBody.search("@" + name);
   // Store toAddress from commiteth
-  if (namePosition == -1) {
+  if (namePosition == -1 && req.body.comment.user.login == 'commiteth') { // TODO no existence check
     issueData[issueId] = {"toAddress": commentBody.substring(commentBody.search("Contract address:") + 18, commentBody.search("Contract address:") + 60)}
     console.log(issueData);
     return res.status(204);
@@ -66,7 +66,6 @@ app.post('/address/:address', jsonParser, function(req, res, next){
         to: issueData[issueId].toAddress, // Address from earlier in the thread
         gas: 100000,
         value: issueData[issueId].amount,
-        data: '0xde5f72fd', // sha3('faucet()')
         nonce,
       }, (err, txID) => {
         if (err) {

--- a/index.js
+++ b/index.js
@@ -4,13 +4,16 @@
  * awards that bounty to the address posted earlier in the thread (by the
  * commiteth bot).
  * TODO tests
+ * REVIEW parsing, non-persisting storage of addresses, hardcoded string length. 
+ * Depends on commiteth version as of 2017-06-10.
  */
 
 const SignerProvider = require('ethjs-provider-signer');
 const sign = require('ethjs-signer').sign;
 const Eth = require('ethjs-query');
 
-const address = process.env.ADDRESS
+const address = process.env.ADDRESS;
+const name = process.env.NAME;
 
 const provider = new SignerProvider(process.env.NODE, {
   signTransaction: (rawTx, cb) => cb(null, sign(rawTx, process.env.KEY)),
@@ -24,30 +27,59 @@ var express = require('express'),
     bodyParser = require('body-parser'),
     jsonParser = bodyParser.json();
 
-app.use(jsonParser);
 app.use(cors());
 
+// Store issue ids and their bounty addresses
+var issueData = {};
+
 // Receive a POST request at the address specified by an env. var.
-app.post('/address/:address', function(req, res, next){
-  eth.getTransactionCount(address, (err, nonce) => {
-    eth.sendTransaction({
-      from: address, // Specified in webhook, secret
-      to: req.params.address, // TODO replace with address from earlier in the thread
-      gas: 100000,
-      value: (parseFloat(process.env.AMOUNT) || 1.5) * 1e18, // TODO replace with parsed amount from comments
-      data: '0xde5f72fd', // sha3('faucet()')
-      nonce,
-    }, (err, txID) => {
-      if (err) {
-        console.log('Request failed', err)
-        return res.status(500).json(err)
+app.post('/address/:address', jsonParser, function(req, res, next){
+  if (!req.body)
+    return res.sendStatus(400);
+  var commentBody = req.body.comment.body;
+  var issueId = req.body.issue.id;
+  var namePosition = commentBody.search("@" + name);
+  // Store toAddress from commiteth
+  if (namePosition == -1) {
+    issueData[issueId] = {"toAddress": commentBody.substring(commentBody.search("Contract address:") + 18, commentBody.search("Contract address:") + 60)}
+    console.log(issueData);
+    return res.status(204);
+  }
+  else {
+    var postNameWords = commentBody.substring(namePosition + 1 + name.length + 1).trim().split(' ');
+    var amount = 0;
+    if (postNameWords.length > 0) {
+      if(postNameWords[0] == "standard") {
+        amount = process.env.STANDARD_BOUNTY;
       }
       else {
-        console.log('Successful request:', txID)
-        res.json({ txID })
+        amount = parseFloat(postNameWords[0]);
       }
+    }
+    console.log("Trying to give " + amount + " ETH to " + issueData[issueId].toAddress + " for issue " + issueId);
+    issueData[issueId].amount = amount;
+
+    // Conduct the transaction
+    eth.getTransactionCount(address, (err, nonce) => {
+      eth.sendTransaction({
+        from: address, // Specified in webhook, secret
+        to: issueData[issueId].toAddress, // Address from earlier in the thread
+        gas: 100000,
+        value: issueData[issueId].amount,
+        data: '0xde5f72fd', // sha3('faucet()')
+        nonce,
+      }, (err, txID) => {
+        if (err) {
+          console.log('Request failed', err)
+          return res.status(500).json(err)
+        }
+        else {
+          console.log('Successful request:', txID)
+          res.json({ txID })
+        }
+      });
     });
-  });
+  }
 });
 
 const port = process.env.PORT || 8181

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
  * and in case it's a comment that has "@autobounty <decimal> <currency>"
  * awards that bounty to the address posted earlier in the thread (by the
  * commiteth bot).
+ * TODO tests
  */
 
 const SignerProvider = require('ethjs-provider-signer');
@@ -43,9 +44,10 @@ app.post('/address/:address', function(req, res, next){
         res.json({ txID })
       }
     });
-  })
+  });
 });
 
 const port = process.env.PORT || 8181
 app.listen(port, function(){
   console.log('Autobounty listening on port', port);
+});

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "body-parser": "^1.17.2",
     "cors": "^2.8.1",
     "ethjs-provider-signer": "^0.1.4",
     "ethjs-query": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "kovan-faucet",
+  "name": "autobounty",
   "version": "1.0.0",
-  "description": "",
+  "description": "Automatically award bounty specified to the address in issue tracker",
   "main": "index.js",
   "scripts": {
     "start": "node index.js",


### PR DESCRIPTION
Fixes #1.

### Implementation
Commiteth bot comments with address and bounty, address is parsed and stored in a dict (key is issueId, from the POST webhook). This is not persistent across server restart.
When a comment says `@autobounty x ETH` tries to award `x` ETH to the previously stored address. 

### Code review focus
Must check security / robustness of the string parsing, for both address and amount.
Authentication for who is allowed to award ETH.

### Testing
Curl:
```
echo '{"comment":{"body":"Contract address: 0x19d8acac27553ef390d287b532b"}, "issue":{"id":234234}}' | curl -H "Content-Type: application/json" -X POST -d @- localhost:8181/address/1

echo '{"text": "Hello **world**!", "comment":{"body":"@autobounty 1 ETH"}, "issue":{"id":234234}}' | curl -H "Content-Type: application/json" -X POST -d @- localhost:8181/address/1
```
Didn't write automated tests or test manually with an actual Github webhook.